### PR TITLE
Make chip-energy and system-energy really the accumulative of power

### DIFF
--- a/src/occ/proc/proc_pstate.c
+++ b/src/occ/proc/proc_pstate.c
@@ -1129,8 +1129,8 @@ void populate_sensor_tbl_to_mem()
 	}
 
     G_sensor_table.count++;
-    G_sensor_table.chip_energy = AMECSENSOR_PTR(PWR250USP0)->accumulator;
-    G_sensor_table.system_energy = AMECSENSOR_PTR(PWR250US)->accumulator;
+    G_sensor_table.chip_energy = AMECSENSOR_PTR(PWR250USP0)->accumulator / 4000;
+    G_sensor_table.system_energy = AMECSENSOR_PTR(PWR250US)->accumulator / 4000;
 
     do
     {


### PR DESCRIPTION
Make chip-energy and system-energy really the accumulative of power (i.e. ENERGY in joule) by multiplying the accumulated POWER (in Watts) during sensor_update by the fixed sample TIME interval (assuming 250 microseconds, i.e. 250 \* 10^-6 Seconds or 1/4000 Seconds).

Tested on a palmetto: 

wei@p2:/sys/devices/system/cpu/occ_sensors$ get-chip-energy.sh 2
(75041 - 74961) / 2
40.00000000000000000000
wei@p2:/sys/devices/system/cpu/occ_sensors$ get-system-enrgy.sh  2 
(1507817 - 1506204) / 2
806.50000000000000000000
wei@p2:/sys/devices/system/cpu/occ_sensors$ cat chip0/power
41 Watts
wei@p2:/sys/devices/system/cpu/occ_sensors$ cat system/power 
808 Watts

The difference between two reads of chip-energy and system-energy should make better sense than the absolute value of chip-energy and system-energy. 
In addition, by simply dividing 4000, the counter is wrapped less.  
Or maybe  >> 12 (i.e. divide by 4096) for less overhead? 
